### PR TITLE
State that it "paves the way for repr. builds" in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 # Purpose
 
-The purpose of molior is to build Debian packages out of git repositories based on a mirror of a specific Debian version and therefore creating reproducible builds. Build environments are structured into projects and versions, which may include mirrors and versions of other projects.
+The purpose of molior is to build Debian packages out of git repositories based on a mirror of a specific Debian version
+and with that paving the way for reproducible builds. Build environments are structured into projects and versions,
+which may include mirrors and versions of other projects.
 
 Molior performs the following tasks:
 - create mirrors of Debian repositories


### PR DESCRIPTION
molior doesn't really *create reproducible builds* just by itself. However, it certainly *paves the way* to do so.
There is a lot more to [reproducible builds](https://wiki.debian.org/ReproducibleBuilds/Howto) than just the build environment.