### PR TITLE
support epoch versions

### DIFF
--- a/molior/molior/utils.py
+++ b/molior/molior/utils.py
@@ -85,3 +85,10 @@ async def get_changelog_attr(name, path):
         raise Exception("error running dpkg-parsechangelog")
 
     return attr.strip()
+
+
+def strip_epoch_version(version):
+    m = re.match("(?:\d+:)?(\d.+)", version)
+    if m:
+        version = m.groups()[0]
+    return version

--- a/molior/ops/deb_build.py
+++ b/molior/ops/deb_build.py
@@ -21,7 +21,7 @@ from molior.model.buildvariant import BuildVariant
 from molior.model.architecture import Architecture
 from molior.model.projectversion import ProjectVersion, get_projectversion_deps
 from molior.molior.logger import get_logger
-from molior.molior.utils import get_changelog_attr
+from molior.molior.utils import get_changelog_attr, strip_epoch_version
 
 from molior.molior.core import (
     get_target_arch,
@@ -162,7 +162,8 @@ async def BuildProcess(task_queue, aptly_queue, parent_build_id, repo_id, git_re
         if ret != 0:
             logger.error("error running git describe")
         else:
-            if not re.match("^v?{}$".format(info.version.replace("~", "-")), gittag):
+            v = strip_epoch_version(info.version)
+            if not re.match("^v?{}$".format(v.replace("~", "-")), gittag):
                 is_ci = True
 
         ci_cfg = Configuration().ci_builds

--- a/pkgs/molior-client-http/usr/lib/molior/build-script
+++ b/pkgs/molior-client-http/usr/lib/molior/build-script
@@ -129,6 +129,9 @@ if [ -z "$pkgdir" ]; then
   exit 1
 fi
 
+# strip epoch version
+VERSION=`echo $VERSION | sed 's/^[0-9]\+://'`
+
 dsc_url="$APT_SERVER/$PLATFORM/$PLATFORM_VERSION/repos/$PROJECT/$PROJECTVERSION/$pkgdir/${REPO_NAME}_$VERSION.dsc"
 log "Downloading $dsc_url"
 wget -q $dsc_url


### PR DESCRIPTION
Debian supports version epochs separated by colon (:). Such epoch versions
only appear in the debian/changelog files, but are not visible in filenames.

This change strips out epoch versions where needed.

Signed-off-by: André Roth <neolynx@gmail.com>