### PR TITLE
mirror: allow slash in distribution

### DIFF
--- a/molior/aptly/api.py
+++ b/molior/aptly/api.py
@@ -482,7 +482,8 @@ class AptlyApi:
         name, publish_name = self.get_aptly_names(base_mirror, base_mirror_version, mirror, version, is_mirror=True)
 
         data = {
-            "Distribution": mirror_distribution,
+            # Workaround for aptly ('/' not supported as mirror dist)
+            "Distribution": mirror_distribution.replace("/", "_-"),
             "SourceKind": "snapshot",
             "Sources": [],
             "Signing": {

--- a/molior/model/projectversion.py
+++ b/molior/model/projectversion.py
@@ -86,7 +86,9 @@ class ProjectVersion(Base):  # pylint: disable=too-few-public-methods
 
         if self.project.is_basemirror:
             url = "{0}/{1}/{2}".format(base_url, self.project.name, self.name)
-            full = "deb {0} {1} {2}".format(url, self.mirror_distribution, self.mirror_components.replace(",", " "))
+            # Workaround for aptly ('/' not supported as mirror dist)
+            full = "deb {0} {1} {2}".format(url, self.mirror_distribution.replace("/", "_-"),
+                                            self.mirror_components.replace(",", " "))
             return url if url_only else full
 
         if not self.buildvariants:
@@ -98,7 +100,9 @@ class ProjectVersion(Base):  # pylint: disable=too-few-public-methods
 
         if self.project.is_mirror:
             url = "{0}/{1}/mirrors/{2}/{3}".format(base_url, base_mirror, self.project.name, self.name)
-            full = "deb {0} {1} {2}".format(url, self.mirror_distribution, self.mirror_components.replace(",", " "))
+            # Workaround for aptly ('/' not supported as mirror dist)
+            full = "deb {0} {1} {2}".format(url, self.mirror_distribution.replace("/", "_-"),
+                                            self.mirror_components.replace(",", " "))
             return url if url_only else full
 
         url = "{0}/{1}/repos/{2}/{3}".format(base_url, base_mirror, self.project.name, self.name)

--- a/molior/molior/worker_aptly.py
+++ b/molior/molior/worker_aptly.py
@@ -459,9 +459,6 @@ class AptlyWorker:
             download_installer,
         ) = args
 
-        # Workaround for aptly ('/' not supported as mirror dist)
-        mirror_distribution = mirror_distribution.replace("/", "-")
-
         build = Build(
             version=version,
             git_ref=None,


### PR DESCRIPTION
the mirror_distribution might contain a slash, but
aptly does not support / when publishing.

example mirror:
deb http://security.debian.org/debian-security jessie/updates main

will become the following in aptly:
deb http://aptly/... jessie_-updates main

Signed-off-by: André Roth <neolynx@gmail.com>