### PR TITLE
Fix empty components string splitting

### DIFF
--- a/molior/molior/worker_aptly.py
+++ b/molior/molior/worker_aptly.py
@@ -607,7 +607,11 @@ class AptlyWorker:
                         mirror.basemirror.name if mirror.basemirror else "",
                         mirror.mirror_url,
                         mirror.mirror_distribution,
-                        mirror.mirror_components.split(","),  # FIXME: should be array in db
+                        # FIXME: should be array in db
+                        # NOTE: return empty array when the components are empty, because
+                        # the default `.split()` algorythm returns `[""]` when
+                        # an empty string is given: https://stackoverflow.com/a/16645307/12356463
+                        mirror.mirror_components.split(",") if mirror.mirror_components else [],
                         db2array(mirror.mirror_architectures),
                         mirror.mirror_filter,
                         download_sources=mirror.mirror_with_sources,


### PR DESCRIPTION
Otherwise when an empty component is given, the
call will forward `[""]` to the aptly api, wich
will result in the error:

> https://github.com/aptly-dev/aptly/blob/71fd7305988aa727a32705c6ca28dc30bf643ad8/deb/remote.go#L110