### PR TITLE
Reset git repository instead of recloning it

### DIFF
--- a/molior/ops/git.py
+++ b/molior/ops/git.py
@@ -180,9 +180,9 @@ async def GitCheckout(repo_path, git_ref, build_id):
             logger.error("checkout: build %d not found", build_id)
             return False
 
-        if not await GitCleanLocal(repo_path, build):
-            return False
         if not await run_git("git fetch --tags --prune --prune-tags --force", repo_path, build, write_output_log=False):
+            return False
+        if not await run_git("git reset --hard origin", repo_path, build, write_output_log=False):
             return False
         if not await run_git("git checkout --force {}".format(git_ref), repo_path, build, write_output_log=False):
             return False


### PR DESCRIPTION
Recloning the repo takes too long so we just reset to the origin state: https://stackoverflow.com/a/54323316/12356463